### PR TITLE
Some new features ;)

### DIFF
--- a/app/js/index.coffee
+++ b/app/js/index.coffee
@@ -1,5 +1,17 @@
 $(document).on( "templateinit", (event) ->
 
+  class MaxCulContactItem extends pimatic.ContactItem
+
+    getItemTemplate: => 'maxcul-contact'
+
+    constructor: (templData, @device) ->
+      super(templData, @device)
+
+    writeConfigToDevice: ->
+      @device.rest.transferConfigToDevice()
+        .done(ajaxShowToast)
+        .fail(ajaxAlertFail)
+
   class MaxCulThermostatItem extends pimatic.DeviceItem
 
     constructor: (templData, @device) ->
@@ -132,8 +144,8 @@ $(document).on( "templateinit", (event) ->
       else
         pimatic.showToast("Input is not valid, it must be between 4.5 (off) and 30.5 (full on)")
 
-
   # register the item-class
   pimatic.templateClasses['maxcul-heating-thermostat'] = MaxCulThermostatItem
   pimatic.templateClasses['maxcul-wall-thermostat'] = MaxCulThermostatItem
+  pimatic.templateClasses['maxcul-contact'] = MaxCulContactItem
 )

--- a/app/js/index.coffee
+++ b/app/js/index.coffee
@@ -131,6 +131,8 @@ $(document).on( "templateinit", (event) ->
           pimatic.showToast("Input is not valid, it must be between 4.5 (off) and 30.5 (full on)")
       else
         pimatic.showToast("Input is not valid, it must be between 4.5 (off) and 30.5 (full on)")
+
+
   # register the item-class
   pimatic.templateClasses['maxcul-heating-thermostat'] = MaxCulThermostatItem
 )

--- a/app/js/index.coffee
+++ b/app/js/index.coffee
@@ -131,6 +131,9 @@ $(document).on( "templateinit", (event) ->
           pimatic.showToast("Input is not valid, it must be between 4.5 (off) and 30.5 (full on)")
       else
         pimatic.showToast("Input is not valid, it must be between 4.5 (off) and 30.5 (full on)")
+
+
   # register the item-class
   pimatic.templateClasses['maxcul-heating-thermostat'] = MaxCulThermostatItem
+  pimatic.templateClasses['maxcul-wall-thermostat'] = MaxCulThermostatItem
 )

--- a/app/views/maxcul-heating-thermostat.jade
+++ b/app/views/maxcul-heating-thermostat.jade
@@ -37,3 +37,39 @@ script#maxcul-heating-thermostat-template(type='text/template')
       <!-- ko if: $data.getConfig('guiShowBatteryState') -->
       span.battery(data-bind="template: {name: 'attribute-template', data: $data.device.getAttribute('battery'), afterRender: $data.afterAttributeRender }")
       <!-- /ko -->
+
+script#maxcul-wall-thermostat-template(type='text/template')
+  li.sortable.device.no-header.thermostat.maxcul(data-bind='css: {unsynced: !$data.synced()}')
+    label.device-label(data-bind="text: name, tooltip: $data.labelTooltipHtml")
+    .control-elements
+      .controls.no-carousel-slide
+        <!-- ko if: $data.getConfig('guiShowModeControl')  -->
+        .button-control.ui-controlgroup.ui-controlgroup-horizontal.ui-corner-all.ui-mini.no-carousel-slide(data-role='controlgroup', data-type='horizontal', data-mini='true', data-enhanced='true')
+          .ui-controlgroup-controls
+            a.ui-first-child.ui-btn.ui-corner-all.ui-disabled(name='autoButton', data-bind='click: modeAuto') auto
+            a.ui-btn.ui-corner-all(name='manuButton', data-bind='click: modeManu') manu
+            a.ui-last-child.ui-btn.ui-corner-all(name='boostButton', data-bind='click: modeBoost') boost
+        <!-- /ko -->
+        <!-- ko if: $data.getConfig('guiShowPresetControl')  -->
+        .button-control.ui-controlgroup.ui-controlgroup-horizontal.ui-corner-all.ui-mini.no-carousel-slide(data-role='controlgroup', data-type='horizontal', data-mini='true', data-enhanced='true')
+          .ui-controlgroup-controls
+            a.ui-first-child.ui-btn.ui-corner-all(name='ecoButton', data-bind='click: modeEco') eco
+            a.ui-btn.ui-corner-all(name='comfyButton', data-bind='click: modeComfy') comfy
+            a.ui-last-child.ui-btn.ui-corner-all(name='offButton', data-bind='click: modeOff') off
+        <!-- /ko -->
+        <!-- ko if: $data.getConfig('guiShowTemperatureInput') -->
+        .spinbox.no-carousel-slide
+          input(type='text', data-role='spinbox', name='spin', value='4.5', min='4.5', max='30.5', data-mini='true', step='0.5', data-bind='textInput: inputValue')
+        <!-- /ko -->
+        <!-- ko if: $data.getConfig('guiShowConfigButton') -->
+        .button-control.ui-controlgroup.ui-controlgroup-horizontal.ui-corner-all.ui-mini.no-carousel-slide(data-role='controlgroup', data-type='horizontal', data-mini='true', data-enhanced='true')
+          .ui-controlgroup-controls
+            a.ui-first-child.ui-last-child.ui-btn.ui-corner-all(name='transferConfigButton', data-bind='click: writeConfigToDevice') transfer config
+        <!-- /ko -->
+    .attributes
+      <!-- ko if: $data.getConfig('guiShowMeasuredTemperature') -->
+      span.measured-temperature(data-bind="template: {name: 'attribute-template', data: $data.device.getAttribute('measuredTemperature'), afterRender: $data.afterAttributeRender }")
+      <!-- /ko -->
+      <!-- ko if: $data.getConfig('guiShowBatteryState') -->
+      span.battery(data-bind="template: {name: 'attribute-template', data: $data.device.getAttribute('battery'), afterRender: $data.afterAttributeRender }")
+      <!-- /ko -->

--- a/app/views/maxcul-heating-thermostat.jade
+++ b/app/views/maxcul-heating-thermostat.jade
@@ -73,3 +73,16 @@ script#maxcul-wall-thermostat-template(type='text/template')
       <!-- ko if: $data.getConfig('guiShowBatteryState') -->
       span.battery(data-bind="template: {name: 'attribute-template', data: $data.device.getAttribute('battery'), afterRender: $data.afterAttributeRender }")
       <!-- /ko -->
+
+script#maxcul-contact-template(type='text/template')
+  li.sortable.device.no-header.thermostat.maxcul
+    label.device-label(data-bind="text: name, tooltip: $data.labelTooltipHtml")
+    .control-elements
+      .controls.no-carousel-slide
+        <!-- ko if: $data.getConfig('guiShowConfigButton') -->
+        .button-control.ui-controlgroup.ui-controlgroup-horizontal.ui-corner-all.ui-mini.no-carousel-slide(data-role='controlgroup', data-type='horizontal', data-mini='true', data-enhanced='true')
+          .ui-controlgroup-controls
+            a.ui-first-child.ui-last-child.ui-btn.ui-corner-all(name='transferConfigButton', data-bind='click: writeConfigToDevice') transfer config
+        <!-- /ko -->
+        span.error(data-bind="text: ($data.error() ? $data.error() : '') ")
+        span.attributes(data-bind="template: { name: 'attribute-template', foreach: $data.device.attributes, afterRender: $data.afterAttributeRender }")

--- a/app/views/maxcul-heating-thermostat.jade
+++ b/app/views/maxcul-heating-thermostat.jade
@@ -2,10 +2,6 @@ script#maxcul-heating-thermostat-template(type='text/template')
   li.sortable.device.no-header.thermostat.maxcul(data-bind='css: {unsynced: !$data.synced()}')
     label.device-label(data-bind="text: name, tooltip: $data.labelTooltipHtml")
     .control-elements
-      <!-- ko if: $data.getConfig('guiShowValvePosition')  -->
-      .valve-position
-        .valve-position-bar!='&nbsp'
-      <!-- /ko -->
       .controls.no-carousel-slide
         <!-- ko if: $data.getConfig('guiShowModeControl')  -->
         .button-control.ui-controlgroup.ui-controlgroup-horizontal.ui-corner-all.ui-mini.no-carousel-slide(data-role='controlgroup', data-type='horizontal', data-mini='true', data-enhanced='true')
@@ -31,6 +27,10 @@ script#maxcul-heating-thermostat-template(type='text/template')
             a.ui-first-child.ui-last-child.ui-btn.ui-corner-all(name='transferConfigButton', data-bind='click: writeConfigToDevice') transfer config
         <!-- /ko -->
     .attributes
+      <!-- ko if: $data.getConfig('guiShowValvePosition')  -->
+      .valve-position
+        .valve-position-bar!='&nbsp'
+      <!-- /ko -->
       <!-- ko if: $data.getConfig('guiShowMeasuredTemperature') -->
       span.measured-temperature(data-bind="template: {name: 'attribute-template', data: $data.device.getAttribute('measuredTemperature'), afterRender: $data.afterAttributeRender }")
       <!-- /ko -->

--- a/max-driver.coffee
+++ b/max-driver.coffee
@@ -360,7 +360,7 @@ module.exports = (env) ->
         else if ( packet.getDest() == "000000" ) #The device is new and needs a full pair
           env.logger.debug "beginn pairing of a new device with deviceId #{packet.getSource()}"
           @sendMsg("01", @baseAddress, packet.getSource(), "00", "00", "00", "")
-          @.emit('NewDevice',packet.getSource())
+          @.emit('NewDevice',packet.getSource(), packet.getRawType())
       else
           env.logger.debug ", but pairing is disabled so ignore"
 

--- a/max-driver.coffee
+++ b/max-driver.coffee
@@ -85,8 +85,14 @@ module.exports = (env) ->
           functionName : "ShutterContactState"
           id : "30"
         }
-        cmd40 : "SetTemperature" # Send by the Wallthermostat
-        cmd42 : "WallThermostatControl"
+        cmd40 : {
+          functionName : "WallThermostatSetTemp"
+          id : "40"
+        }
+        cmd42 : {
+          functionName : "WallThermostatControl"
+          id : "42"
+        }
         cmd43 : "SetComfortTemperature"
         cmd44 : "SetEcoTemperature"
         cmd50 : {
@@ -97,7 +103,10 @@ module.exports = (env) ->
           functionName : "ThermostatState"
           id : 60
         }
-        cmd70 : "WallThermostatState"
+        cmd70 : {
+          functionName : "WallThermostatState"
+          id : 70
+        }
         cmd82 : "SetDisplayActualTemperature"
         cmdF1 : "WakeUp"
         cmdF0 : "Reset"
@@ -123,17 +132,17 @@ module.exports = (env) ->
       env.logger.debug "decoding Message #{message}"
       message = message.replace(/\n/, '')
       message = message.replace(/\r/, '')
-      
+
       rssi = parseInt(message.slice(-2), 16)
       if rssi >= 128
         rssi = (rssi - 256) / 2 - 74
       else
         rssi = rssi / 2 - 74
       env.logger.debug "RSSI for Message : #{rssi}"
-      
+
       # remove rssi value from message string
       message = message.substring(0, message.length - 2);
-      
+
       data = message.split(/Z(..)(..)(..)(..)(......)(......)(..)(.*)/)
       data.shift() # Removes first element from array, it is the 'Z'.
 
@@ -215,6 +224,13 @@ module.exports = (env) ->
     sendTimeInformation: (dest, deviceType) ->
       payload = @generateTimePayload()
       @sendMsg("03",@baseAddress,dest,payload,"00","04",deviceType);
+
+    sendGroup: (dest, groupId, deviceType) ->
+      payload = Sprintf('%02x', groupId)
+      @sendMsg("22",@baseAddress,dest,payload,"00","00",deviceType);
+
+    sendPair: (dest, pairId, deviceType) ->
+      @sendMsg("20",@baseAddress,dest,pairId,"00","00",deviceType);
 
     sendConfig: (dest,comfortTemperature,ecoTemperature,minimumTemperature,maximumTemperature,offset,windowOpenTime,windowOpenTemperature,deviceType) ->
       comfortTemperatureValue = Sprintf('%02x',(comfortTemperature*2))
@@ -332,6 +348,60 @@ module.exports = (env) ->
 
       env.logger.debug "got data from push button #{packet.getSource()} #{rawBitData.toString()}"
       @.emit('PushButtonStateRecieved',pushButtonState)
+
+
+    WallThermostatState: (packet) ->
+      env.logger.debug "got data from wallthermostat state #{packet.getSource()} with payload #{packet.getRawPayload()}"
+
+      rawPayload = packet.getRawPayload()
+
+      if( rawPayload.length >= 10)
+        rawPayloadBuffer = new Buffer(rawPayload, 'hex')
+
+        payloadParser = new BinaryParser().uint8('bits').uint8('displaymode').uint8('desiredRaw').uint8('null1').uint8('heaterTemperature')
+
+        rawData = payloadParser.parse(rawPayloadBuffer)
+
+        rawBitData = new BitSet(rawData.bits);
+
+        WallthermostatState =
+          src : packet.getSource()
+          mode : rawBitData.getRange(0,1)
+          desiredTemperature : ('0x'+(packet.getRawPayload().substr(4,2))) & 0x7F) / 2.0
+          measuredTemperature : 0
+          dstSetting : rawBitData.get(3)
+          langateway : rawBitData.get(4)
+          panel : rawBitData.get(5)
+          rferror : rawBitData.get(6)
+          batterylow : rawBitData.get(7)
+
+    WallThermostatControl: (packet) ->
+      rawBitData = new BitSet('0x'+packet.getRawPayload())
+      desiredRaw = '0x'+(packet.getRawPayload().substr(0,2))
+      measuredRaw = '0x'+(packet.getRawPayload().substr(2,2))
+      desired = (desiredRaw & 0x7F) / 2.0
+      measured = ((((desiredRaw & 0x80)*1)<<1) | (measuredRaw)*1)
+      env.logger.debug parseInt(measured) / 10
+
+      WallThermostatControl =
+        src : packet.getSource()
+        desired : desired
+        measured : measured
+      @.emit('WallThermostatControlRecieved',wallSetTemp)
+
+      env.logger.debug "got data from wallthermostat #{packet.getSource()} desired temp: #{desired} - measured temp: #{measured}"
+
+    WallThermostatSetTemp: (packet) ->
+      setTemp = ('0x'+packet.getRawPayload() & 0x3f) / 2.0
+      mode = ('0x'+packet.getRawPayload())>>6
+
+      wallSetTemp =
+        src : packet.getSource()
+        mode : mode
+        temp : setTemp
+      @.emit('WallThermostatSetTempRecieved',wallSetTemp)
+
+      env.logger.debug "got data from wallthermostat #{packet.getSource()} set new temp #{setTemp} mode #{mode}"
 
     ThermostatState: (packet) ->
       env.logger.debug "got data from heatingelement #{packet.getSource()} with payload #{packet.getRawPayload()}"

--- a/max-driver.coffee
+++ b/max-driver.coffee
@@ -269,6 +269,7 @@ module.exports = (env) ->
       @sendMsg("11",@baseAddress,dest,payload,"00","00",deviceType)
       return Promise.resolve true
 
+    #send fake shutter message
     sendShutterMessage: (dest, src, event, groupId, deviceType) ->
       state = if event then "10" else "12"
       if groupId == "00"
@@ -276,27 +277,25 @@ module.exports = (env) ->
       else
         return @sendMsg("30",src,dest,state,groupId,"06",deviceType);
 
+    #send fake wallthermostat message
     sendTemperatureMessage: (dest, measuredTemp, desiredTemp, groupId, deviceType) ->
-
       if measuredTemp < 0
         measuredTemp = 0
       if measuredTemp > 51
         measuredTemp = 51
-
       if desiredTemp <= 4.5
         desiredTemp = 4.5
       if desiredTemp >= 30.5
         desiredTemp = 30.5
-
       val2 = measuredTemp * 10
       val1 = ((val2 & 0x100)>>1) | ((desiredTemp * 2) & 0x7F)
       val2 = val2 & 0xFF
-      payload = Sprintf('%02x%02x',$val1,$val2)
+      payload = Sprintf('%02x%02x',val1,val2)
 
       if groupId == "00"
-        return @sendMsg("42",@baseAddress,dest,payload,"00","00",deviceType);
+        return @sendMsg("42",@baseAddress,dest,payload,"00","00",deviceType)
       else
-        return @sendMsg("42",@baseAddress,dest,payload,groupId,"04",deviceType);
+        return @sendMsg("42",@baseAddress,dest,payload,groupId,"04",deviceType)
 
     sendDesiredTemperature: (dest,temperature,mode,groupId,deviceType) ->
       modeBin = switch mode
@@ -361,7 +360,7 @@ module.exports = (env) ->
         else if ( packet.getDest() == "000000" ) #The device is new and needs a full pair
           env.logger.debug "beginn pairing of a new device with deviceId #{packet.getSource()}"
           @sendMsg("01", @baseAddress, packet.getSource(), "00", "00", "00", "")
-          @.emit('NewDevice',packet.getSource()) 
+          @.emit('NewDevice',packet.getSource())
       else
           env.logger.debug ", but pairing is disabled so ignore"
 

--- a/maxcul-config-schema.coffee
+++ b/maxcul-config-schema.coffee
@@ -14,10 +14,6 @@ module.exports = {
       doc: "The Address of this basestation in the MAX! System Default (123456)"
       type: "string"
       default: "123456"
-    enablePairMode:
-      doc: "Enabled the pair mode, should be false for production because it could interfere with your neighbours"
-      type: "boolean"
-      default: false
     debug:
       doc: "Enabled debug messages"
       type: "boolean"

--- a/maxcul-device-config-schema.coffee
+++ b/maxcul-device-config-schema.coffee
@@ -12,6 +12,10 @@ module.exports = {
         description : "Group/Room id of the Device"
         type: "string"
         default: "00"
+      guiShowConfigButton:
+        description: "Show a button which which when pressed, transfers the config (eco Mode Settings etc.) to the device."
+        type: "boolean"
+        default: false
       pairIds:
         description : "Group/Room id of the Device"
         type: "array"
@@ -76,6 +80,10 @@ module.exports = {
         description : "Group/Room id of the Device"
         type: "string"
         default: "00"
+      guiShowConfigButton:
+        description: "Show a button which which when pressed, transfers the config (eco Mode Settings etc.) to the device."
+        type: "boolean"
+        default: false
       pairIds:
         description : "Group/Room id of the Device"
         type: "array"
@@ -293,6 +301,10 @@ module.exports = {
               type: "string"
               enum: ["HeatingThermostat","ShutterContact"]
               required: true
+      refTemp:
+        description: "The reference temperature expression"
+        type: "string"
+        required: true
       comfyTemp:
         description: "The defined comfort mode temperature"
         type: "number"

--- a/maxcul-device-config-schema.coffee
+++ b/maxcul-device-config-schema.coffee
@@ -4,44 +4,96 @@ module.exports = {
     title: "Config options for the Maxcul ShutterContact"
     type: "object"
     properties: {
-      id:
-        description: "ID of the Device"
-        type: "string"
-        default: ""
       deviceId:
         description: "ID of the Device in the MAX! Network"
-        type: "string"
-        default: "000000"
-      name:
-        description: "Name of the Device"
         type: "string"
         default: "000000"
       groupId:
         description : "Group/Room id of the Device"
         type: "string"
         default: "00"
+      pairIds:
+        description : "Group/Room id of the Device"
+        type: "array"
+        default: []
+        format: "table"
+        items:
+          type: "object"
+          required: ["pairId"]
+          properties:
+            pairId:
+              description: "Id of the pairing device"
+              type:"string"
+              required: true
+            type:
+              description: "Device typ"
+              type: "string"
+              enum: ["HeatingThermostat","WallMountedThermostat"]
+              required: true
+    }
+  },
+  MaxculFakeShutterContact:{
+    title: "Config options for the Maxcul ShutterContact"
+    type: "object"
+    properties: {
+      deviceId:
+        description: "Fake ID of the Device in the MAX! Network"
+        type: "string"
+        default: "111111"
+      groupId:
+        description : "Group/Room id of the Device"
+        type: "string"
+        default: "00"
+      pairIds:
+        description : "Group/Room id of the Device"
+        type: "array"
+        default: []
+        format: "table"
+        items:
+          type: "object"
+          required: ["pairId"]
+          properties:
+            pairId:
+              description: "Id of the pairing device"
+              type:"string"
+              required: true
+            type:
+              description: "Device typ"
+              type: "string"
+              enum: ["HeatingThermostat","WallMountedThermostat"]
+              required: true
     }
   },
   MaxculPushButton:{
     title: "Config options for the Maxcul PushButton"
     type: "object"
     properties: {
-      id:
-        description: "ID of the Device"
-        type: "string"
-        default: ""
       deviceId:
         description: "ID of the Device in the MAX! Network"
-        type: "string"
-        default: "000000"
-      name:
-        description: "Name of the Device"
         type: "string"
         default: "000000"
       groupId:
         description : "Group/Room id of the Device"
         type: "string"
         default: "00"
+      pairIds:
+        description : "Group/Room id of the Device"
+        type: "array"
+        default: []
+        format: "table"
+        items:
+          type: "object"
+          required: ["pairId"]
+          properties:
+            pairId:
+              description: "Id of the pairing device"
+              type:"string"
+              required: true
+            type:
+              description: "Device typ"
+              type: "string"
+              enum: ["HeatingThermostat","WallMountedThermostat"]
+              required: true
     }
   },
   MaxculHeatingThermostat:{
@@ -49,26 +101,32 @@ module.exports = {
     type: "object"
     extensions: ["xAttributeOptions"]
     properties: {
-      id:
-        description: "ID of the Device"
-        type: "string"
-        default: ""
       deviceId:
         description: "ID of the Device in the MAX! Network"
-        type: "string"
-        default: "000000"
-      name:
-        description: "Name of the Device"
         type: "string"
         default: "000000"
       groupId:
         description : "Group/Room id of the Device"
         type: "string"
         default: "00"
-      pairId:
+      pairIds:
         description : "Group/Room id of the Device"
-        type: "string"
-        default: "000000"
+        type: "array"
+        default: []
+        format: "table"
+        items:
+          type: "object"
+          required: ["pairId"]
+          properties:
+            pairId:
+              description: "Id of the pairing device"
+              type:"string"
+              required: true
+            type:
+              description: "Device typ"
+              type: "string"
+              enum: ["WallMountedThermostat","ShutterContact"]
+              required: true
       comfyTemp:
         description: "The defined comfort mode temperature"
         type: "number"
@@ -140,13 +198,101 @@ module.exports = {
         description : "Group/Room id of the Device"
         type: "string"
         default: "00"
-<<<<<<< HEAD
-      pairId:
+      pairIds:
+        description : "Group/Room id of the Device"
+        type: "array"
+        default: []
+        format: "table"
+        items:
+          type: "object"
+          required: ["pairId"]
+          properties:
+            pairId:
+              description: "Id of the pairing device"
+              type:"string"
+              required: true
+            type:
+              description: "Device typ"
+              type: "string"
+              enum: ["HeatingThermostat","ShutterContact"]
+              required: true
+      comfyTemp:
+        description: "The defined comfort mode temperature"
+        type: "number"
+        default: 21
+      ecoTemp:
+        description: "The defined eco mode temperature"
+        type: "number"
+        default: 17
+      guiShowModeControl:
+        description: "Show the mode buttons in the gui"
+        type: "boolean"
+        default: true
+      guiShowPresetControl:
+        description: "Show the preset temperatures in the gui"
+        type: "boolean"
+        default: true
+      guiShowTemperatureInput:
+        description: "Show the temperature input spinbox in the gui"
+        type: "boolean"
+        default: true
+      guiShowMeasuredTemperature:
+        description: "Show the measured temperature in the gui"
+        type: "boolean"
+        default: true
+      guiShowBatteryState:
+        description: "Show the battery state in the gui"
+        type: "boolean"
+        default: true
+      guiShowConfigButton:
+        description: "Show a button which which when pressed, transfers the config (eco Mode Settings etc.) to the device."
+        type: "boolean"
+        default: false
+      minimumTemperature:
+        description: "The defined minimum temperature that can be set ON THE DEVICE ITSELF"
+        type: "number"
+        default: 4.5
+      maximumTemperature:
+        description: "The defined maximum temperature that can be set ON THE DEVICE ITSELF"
+        type: "number"
+        default: 30.5
+      measurementOffset:
+        description: "The defined measurement offset"
+        type: "number"
+        default: 0
+    }
+  },
+  MaxculFakeWallThermostat:{
+    title: "Config options for the Maxcul WallThermostat"
+    type: "object"
+    extensions: ["xAttributeOptions"]
+    properties: {
+      deviceId:
+        description: "ID of the Device in the MAX! Network"
+        type: "string"
+        default: "222222"
+      groupId:
         description : "Group/Room id of the Device"
         type: "string"
-        default: "000000"  
-=======
->>>>>>> 115f3a030020738f8744f2d1492d7f768c6763fe
+        default: "00"
+      pairIds:
+        description : "Group/Room id of the Device"
+        type: "array"
+        default: []
+        format: "table"
+        items:
+          type: "object"
+          required: ["pairId"]
+          properties:
+            pairId:
+              description: "Id of the pairing device"
+              type:"string"
+              required: true
+            type:
+              description: "Device typ"
+              type: "string"
+              enum: ["HeatingThermostat","ShutterContact"]
+              required: true
       comfyTemp:
         description: "The defined comfort mode temperature"
         type: "number"

--- a/maxcul-device-config-schema.coffee
+++ b/maxcul-device-config-schema.coffee
@@ -9,15 +9,15 @@ module.exports = {
         type: "string"
         default: "000000"
       groupId:
-        description : "Group/Room id of the Device"
+        description: "Group/Room id of the Device"
         type: "string"
         default: "00"
       guiShowConfigButton:
-        description: "Show a button which which when pressed, transfers the config (eco Mode Settings etc.) to the device."
+        description: "Show a button which when pressed, transfers the config to the device."
         type: "boolean"
         default: false
       pairIds:
-        description : "Group/Room id of the Device"
+        description: "List of paired Device"
         type: "array"
         default: []
         format: "table"
@@ -30,7 +30,7 @@ module.exports = {
               type:"string"
               required: true
             type:
-              description: "Device typ"
+              description: "Device type"
               type: "string"
               enum: ["HeatingThermostat","WallMountedThermostat"]
               required: true
@@ -45,11 +45,11 @@ module.exports = {
         type: "string"
         default: "111111"
       groupId:
-        description : "Group/Room id of the Device"
+        description: "Group/Room id of the Device"
         type: "string"
         default: "00"
       pairIds:
-        description : "Group/Room id of the Device"
+        description: "List of paired Device"
         type: "array"
         default: []
         format: "table"
@@ -62,7 +62,7 @@ module.exports = {
               type:"string"
               required: true
             type:
-              description: "Device typ"
+              description: "Device type"
               type: "string"
               enum: ["HeatingThermostat","WallMountedThermostat"]
               required: true
@@ -77,7 +77,7 @@ module.exports = {
         type: "string"
         default: "000000"
       groupId:
-        description : "Group/Room id of the Device"
+        description: "Group/Room id of the Device"
         type: "string"
         default: "00"
       guiShowConfigButton:
@@ -85,7 +85,7 @@ module.exports = {
         type: "boolean"
         default: false
       pairIds:
-        description : "Group/Room id of the Device"
+        description: "List of paired Device"
         type: "array"
         default: []
         format: "table"
@@ -98,7 +98,7 @@ module.exports = {
               type:"string"
               required: true
             type:
-              description: "Device typ"
+              description: "Device type"
               type: "string"
               enum: ["HeatingThermostat","WallMountedThermostat"]
               required: true
@@ -114,11 +114,11 @@ module.exports = {
         type: "string"
         default: "000000"
       groupId:
-        description : "Group/Room id of the Device"
+        description: "Group/Room id of the Device"
         type: "string"
         default: "00"
       pairIds:
-        description : "Group/Room id of the Device"
+        description: "List of paired Device"
         type: "array"
         default: []
         format: "table"
@@ -131,7 +131,7 @@ module.exports = {
               type:"string"
               required: true
             type:
-              description: "Device typ"
+              description: "Device type"
               type: "string"
               enum: ["WallMountedThermostat","ShutterContact"]
               required: true
@@ -203,11 +203,11 @@ module.exports = {
         type: "string"
         default: "000000"
       groupId:
-        description : "Group/Room id of the Device"
+        description: "Group/Room id of the Device"
         type: "string"
         default: "00"
       pairIds:
-        description : "Group/Room id of the Device"
+        description: "List of paired Device"
         type: "array"
         default: []
         format: "table"
@@ -220,7 +220,7 @@ module.exports = {
               type:"string"
               required: true
             type:
-              description: "Device typ"
+              description: "Device type"
               type: "string"
               enum: ["HeatingThermostat","ShutterContact"]
               required: true
@@ -280,11 +280,11 @@ module.exports = {
         type: "string"
         default: "222222"
       groupId:
-        description : "Group/Room id of the Device"
+        description: "Group/Room id of the Device"
         type: "string"
         default: "00"
       pairIds:
-        description : "Group/Room id of the Device"
+        description: "List of paired Device"
         type: "array"
         default: []
         format: "table"

--- a/maxcul-device-config-schema.coffee
+++ b/maxcul-device-config-schema.coffee
@@ -122,5 +122,64 @@ module.exports = {
         type: "number"
         default: 4.5
     }
+  },
+  MaxculWallThermostat:{
+    title: "Config options for the Maxcul WallThermostat"
+    type: "object"
+    extensions: ["xAttributeOptions"]
+    properties: {
+      deviceId:
+        description: "ID of the Device in the MAX! Network"
+        type: "string"
+        default: "000000"
+      groupId:
+        description : "Group/Room id of the Device"
+        type: "string"
+        default: "00"
+      comfyTemp:
+        description: "The defined comfort mode temperature"
+        type: "number"
+        default: 21
+      ecoTemp:
+        description: "The defined eco mode temperature"
+        type: "number"
+        default: 17
+      guiShowModeControl:
+        description: "Show the mode buttons in the gui"
+        type: "boolean"
+        default: true
+      guiShowPresetControl:
+        description: "Show the preset temperatures in the gui"
+        type: "boolean"
+        default: true
+      guiShowTemperatureInput:
+        description: "Show the temperature input spinbox in the gui"
+        type: "boolean"
+        default: true
+      guiShowMeasuredTemperature:
+        description: "Show the measured temperature in the gui"
+        type: "boolean"
+        default: true
+      guiShowBatteryState:
+        description: "Show the battery state in the gui"
+        type: "boolean"
+        default: true
+      guiShowConfigButton:
+        description: "Show a button which which when pressed, transfers the config (eco Mode Settings etc.) to the device."
+        type: "boolean"
+        default: false
+      minimumTemperature:
+        description: "The defined minimum temperature that can be set ON THE DEVICE ITSELF"
+        type: "number"
+        default: 4.5
+      maximumTemperature:
+        description: "The defined maximum temperature that can be set ON THE DEVICE ITSELF"
+        type: "number"
+        default: 30.5
+      measurementOffset:
+        description: "The defined measurement offset"
+        type: "number"
+        default: 0
+    }
   }
 }

--- a/maxcul-device-config-schema.coffee
+++ b/maxcul-device-config-schema.coffee
@@ -65,6 +65,10 @@ module.exports = {
         description : "Group/Room id of the Device"
         type: "string"
         default: "00"
+      pairId:
+        description : "Group/Room id of the Device"
+        type: "string"
+        default: "000000"
       comfyTemp:
         description: "The defined comfort mode temperature"
         type: "number"
@@ -121,6 +125,69 @@ module.exports = {
         description: "The defined window open temperature mode temperature"
         type: "number"
         default: 4.5
+    }
+  },
+  MaxculWallThermostat:{
+    title: "Config options for the Maxcul WallThermostat"
+    type: "object"
+    extensions: ["xAttributeOptions"]
+    properties: {
+      deviceId:
+        description: "ID of the Device in the MAX! Network"
+        type: "string"
+        default: "000000"
+      groupId:
+        description : "Group/Room id of the Device"
+        type: "string"
+        default: "00"
+      pairId:
+        description : "Group/Room id of the Device"
+        type: "string"
+        default: "000000"  
+      comfyTemp:
+        description: "The defined comfort mode temperature"
+        type: "number"
+        default: 21
+      ecoTemp:
+        description: "The defined eco mode temperature"
+        type: "number"
+        default: 17
+      guiShowModeControl:
+        description: "Show the mode buttons in the gui"
+        type: "boolean"
+        default: true
+      guiShowPresetControl:
+        description: "Show the preset temperatures in the gui"
+        type: "boolean"
+        default: true
+      guiShowTemperatureInput:
+        description: "Show the temperature input spinbox in the gui"
+        type: "boolean"
+        default: true
+      guiShowMeasuredTemperature:
+        description: "Show the measured temperature in the gui"
+        type: "boolean"
+        default: true
+      guiShowBatteryState:
+        description: "Show the battery state in the gui"
+        type: "boolean"
+        default: true
+      guiShowConfigButton:
+        description: "Show a button which which when pressed, transfers the config (eco Mode Settings etc.) to the device."
+        type: "boolean"
+        default: false
+      minimumTemperature:
+        description: "The defined minimum temperature that can be set ON THE DEVICE ITSELF"
+        type: "number"
+        default: 4.5
+      maximumTemperature:
+        description: "The defined maximum temperature that can be set ON THE DEVICE ITSELF"
+        type: "number"
+        default: 30.5
+      measurementOffset:
+        description: "The defined measurement offset"
+        type: "number"
+        default: 0
     }
   }
 }

--- a/maxcul.coffee
+++ b/maxcul.coffee
@@ -64,8 +64,7 @@ module.exports = (env) ->
       @maxDriver.on('NewDevice', (device,type) =>
         config = {
           name: "maxcul_#{device}",
-          id: "maxcul_#{device}",
-          address: device['9003']
+          id: "maxcul_#{device}"
         }
         @framework.deviceManager.discoveredDevice( 'pimatic-maxcul ', "New max device: #{config.name}", config )
       )

--- a/maxcul.coffee
+++ b/maxcul.coffee
@@ -276,8 +276,9 @@ module.exports = (env) ->
       @addAttribute(
         'battery',
         {
+          label: "Battery State"
           description: "state of the battery"
-          type: "boolean"
+          type: "string"
           labels: ['low', 'ok']
           acronym: "Bat."
         }
@@ -303,9 +304,11 @@ module.exports = (env) ->
     getBattery:() -> Promise.resolve(@_battery)
 
     _setBattery: (value) ->
-      if @_battery is value then return
-      @_battery = value
-      @emit 'battery', value
+      if ( value == 0 )
+        @_battery = "ok"
+      else
+        @_battery = "low"
+      @emit 'battery', @_battery
 
     handleReceivedCmd: (command) ->
 
@@ -378,8 +381,9 @@ module.exports = (env) ->
       @addAttribute(
         'battery',
         {
+          label: "Battery State"
           description: "state of the battery"
-          type: "boolean"
+          type: "string"
           labels: ['low', 'ok']
           acronym: "Bat."
         }
@@ -405,9 +409,11 @@ module.exports = (env) ->
     getBattery:() -> Promise.resolve(@_battery)
   
     _setBattery: (value) ->
-      if @_battery is value then return
-      @_battery = value
-      @emit 'battery', value
+      if ( value == 0 )
+        @_battery = "ok"
+      else
+        @_battery = "low"
+      @emit 'battery', @_battery
 
     _setContact: (value) ->
       if @_contact is value then return

--- a/maxcul.coffee
+++ b/maxcul.coffee
@@ -22,12 +22,14 @@ module.exports = (env) ->
       deviceConfigDef = require("./maxcul-device-config-schema")
       deviceTypeClasseNames = [
         MaxculShutterContact,
+        MaxculFakeShutterContact,
         MaxculHeatingThermostat,
         MaxculPushButton,
-        MaxculWallThermostat
+        MaxculWallThermostat,
+        MaxculFakeWallThermostat
       ]
 
-      @maxDriver = new MaxDriver(baseAddress, @config.enablePairMode, @config.serialPortName, @config.baudrate)
+      @maxDriver = new MaxDriver(baseAddress, @config.serialPortName, @config.baudrate)
       @maxDriver.connect()
       @availableDevices = []
 
@@ -55,291 +57,16 @@ module.exports = (env) ->
         else
           env.logger.warn "maxcul could not find the mobile-frontend. No gui will be available"
 
+      @framework.deviceManager.on 'discover', (eventData) =>
+        @framework.deviceManager.discoverMessage 'pimatic-maxcul', "pairmode for 30 sec enabled"
+        @maxDriver.enablePairMode()
+
     # Class that represents a MAX! HeatingThermostat
-    class MaxculHeatingThermostat extends env.devices.HeatingThermostat
-
-      @_decalcDays: ["Sat","Sun","Mon","Tue","Wed","Thu","Fri"]
-      @_modes: ["auto", "manu", "temporary", "boost"]
-      @_boostDurations: [0,5,10,15,20,25,30,60]
-
-      @deviceType: "HeatingThermostat"
-      template: "maxcul-heating-thermostat"
-
-      _extendetAttributes:[
-        {
-          name: 'measuredTemperature'
-          settings:
-            label: "Measured Temperature"
-            description: "The temp that the device has measured"
-            type: "number"
-            acronym: "T"
-            unit: "°C"
-        },
-        {
-          name: 'battery'
-          settings:
-            label: "Battery State"
-            description: "state of the battery"
-            type: "string"
-            labels: ['low', 'ok']
-            acronym: "Bat."
-        }
-      ]
-
-      constructor: (@config, lastState, @maxDriver, index) ->
-        @id = @config.id
-        @_index = index
-        @name = @config.name
-        @_deviceId = @config.deviceId.toLowerCase()
-        @_mode = lastState?.mode?.value or "auto"
-        @_battery = lastState?.battery?.value or "ok"
-        @_temperatureSetpoint = lastState?.temperatureSetpoint?.value or 17
-        @_measuredTemperature = lastState?.measuredTemperature?.value
-        @_lastSendTime = 0
-
-        @_comfortTemperature = @config.comfyTemp
-        @_ecoTemperature = @config.ecoTemp
-        @_minimumTemperature = @config.minimumTemperature
-        @_maximumTemperature = @config.maximumTemperature
-        @_measurementOffset = @config.measurementOffset
-        @_windowOpenTime = @config.windowOpenTime
-        @_windowOpenTemperature = @config.windowOpenTemperature
-        @_valve = lastState?.valve?.value
-
-        @_groupId = @config.groupId.toLowerCase()
-        @_pairId = @config.pairId.toLowerCase()
-
-
-        @_timeInformationHour = ""
-
-        @actions['transferConfigToDevice'] =
-          params:{}
-
-        for Attribute in @_extendetAttributes
-          do (Attribute) =>
-            @addAttribute(Attribute.name,Attribute.settings)
-
-        @maxDriver.on('checkTimeIntervalFired', checkTimeIntervalFiredHandler = () =>
-          @_updateTimeInformation()
-        )
-
-        @maxDriver.on('deviceRequestTimeInformation',deviceRequestTimeInformationHandlder = (device) =>
-          if device == @_deviceId
-            @_updateTimeInformation()
-        )
-
-        @maxDriver.on('ThermostatStateRecieved', thermostatStateRecievedHandler = (thermostatState) =>
-          if(@_deviceId == thermostatState.src)
-            @_setBattery(thermostatState.batterylow)
-            @_setMode(@constructor._modes[thermostatState.mode])
-            @_setSetpoint(thermostatState.desiredTemperature)
-            if( thermostatState.measuredTemperature != 0)
-              @_setMeasuredTemperature(thermostatState.measuredTemperature)
-            @_setValve(thermostatState.valvePosition)
-        )
-
-        @on('destroy', () =>
-          @maxDriver.removeListener('deviceRequestTimeInformation', deviceRequestTimeInformationHandlder)
-          @maxDriver.removeListener('ThermostatStateRecieved', thermostatStateRecievedHandler)
-          @maxDriver.removeListener('checkTimeIntervalFired', checkTimeIntervalFiredHandler)
-
-          env.logger.debug "Thermostat #{@_deviceId} handlers removed"
-        )
-
-        super()
-
-      _setMeasuredTemperature: (measuredTemperature) ->
-        if @_measuredTemperature is measuredTemperature then return
-        @_measuredTemperature = measuredTemperature
-        @emit 'measuredTemperature', measuredTemperature
-
-      _setBattery: (value) ->
-        if ( value == 0 )
-          @_battery = "ok"
-        else
-          @_battery = "low"
-        @emit 'battery', @_battery
-
-      _setValve: (value) ->
-        if @_valve is value then return
-        @_valve = value
-        @emit 'valve', value
-
-      _updateTimeInformation: () ->
-        env.logger.debug "Updating time information for deviceId #{@_deviceId}"
-        @maxDriver.sendTimeInformation(@_deviceId,@constructor.deviceType)
-
-      changeModeTo: (mode) ->
-        if @_mode is mode then return Promise.resolve true
-
-        if mode is "auto"
-          temperatureSetpoint = null
-        else
-          temperatureSetpoint = @_temperatureSetpoint
-          env.logger.debug "Set desired mode to #{mode} for deviceId #{@_deviceId}"
-
-        @maxDriver.sendDesiredTemperature(@_deviceId, temperatureSetpoint, mode, "00", @constructor.deviceType).then( =>
-          @_lastSendTime = new Date().getTime()
-          @_setMode(mode)
-          @_setSetpoint(temperatureSetpoint)
-          return Promise.resolve true
-        ).catch ( (err) =>
-           return Promise.reject err
-        )
-
-      changeTemperatureTo: (temperatureSetpoint) ->
-        if @_temperatureSetpoint is temperatureSetpoint then return Promise.resolve true
-        env.logger.debug "Set desired temperature #{temperatureSetpoint} for deviceId #{@_deviceId}"
-        @maxDriver.sendDesiredTemperature(@_deviceId, temperatureSetpoint, @_mode, "00", @constructor.deviceType).then( =>
-          @_lastSendTime = new Date().getTime()
-          @_setSynced(true)
-          @_setSetpoint(temperatureSetpoint)
-          return Promise.resolve true
-        ).catch( (err) =>
-          return Promise.reject err
-        )
-
-      transferConfigToDevice: () ->
-        env.logger.info "transfer config to device #{@_deviceId}"
-        if @_pairId != "000000"
-          @maxDriver.sendPair(@_deviceId,@_pairId,3,@constructor.deviceType)
-          env.logger.info "send pairId #{@_pairId} to device #{@_deviceId}"
-        if @_groupId != "00"
-          @maxDriver.sendGroup(@_deviceId,@_groupId,@constructor.deviceType)
-
-        return @maxDriver.sendConfig(
-            @_deviceId,
-            @_comfortTemperature,
-            @_ecoTemperature,
-            @_minimumTemperature,
-            @_maximumTemperature,
-            @_measurementOffset,
-            @_windowOpenTime,
-            @_windowOpenTemperature,
-            @constructor.deviceType
-          )
-
-      getEcoTemperature: () -> Promise.resolve(@_ecoTemperature)
-      getComfortTemperature: () -> Promise.resolve(@_comfortTemperature)
-      getMeasuredTemperature: () -> Promise.resolve(@_measuredTemperature)
-
-      getTemplateName: -> "maxcul-heating-thermostat"
-
-      destroy: ->
-        env.logger.debug "Thermostat #{@_deviceId} destroyed"
-        super()
-
-    # Class that represents a MAX! ShutterContact
-    class MaxculShutterContact extends env.devices.ContactSensor
-
-      @deviceType = "ShutterContact"
-
-      constructor: (@config, lastState, @maxDriver, index) ->
-        @id = @config.id
-        @name = @config.name
-        @_deviceId = @config.deviceId.toLowerCase()
-        @_contact = lastState?.contact?.value
-        @_battery = lastState?.battery?.value
-        @_index = index
-
-        @addAttribute(
-          'battery',
-          {
-            description: "state of the battery"
-            type: "boolean"
-            labels: ['low', 'ok']
-            acronym: "Bat."
-          }
-        )
-
-        @maxDriver.on('ShutterContactStateRecieved',shutterContactStateReceivedHandler = (shutterContactState) =>
-          if(@_deviceId == shutterContactState.src)
-            # If the window is open the isOpen field is true the contact is open = false
-            @_setContact(if shutterContactState.isOpen then false else true)
-            @_setBattery(shutterContactState.batteryLow)
-            env.logger.debug "ShutterContact with deviceId #{@_deviceId} updated"
-        )
-
-        @on('destroy', () =>
-          @maxDriver.removeListener('ShutterContactStateRecieved', shutterContactStateReceivedHandler)
-          env.logger.debug "ShutterContact #{@_deviceId} ShutterContactStateRecieved handler removed"
-        )
-
-        super()
-
-      getBattery:() -> Promise.resolve(@_battery)
-
-      _setBattery: (value) ->
-        if @_battery is value then return
-        @_battery = value
-        @emit 'battery', value
-
-      handleReceivedCmd: (command) ->
-
-      destroy: ->
-        env.logger.debug "ShutterContact #{@_deviceId} destroyed"
-        super()
-
-    # Class that represents a MAX! PushButton
-    class MaxculPushButton extends env.devices.ContactSensor
-
-      @deviceType = "PushButton"
-
-      constructor: (@config, lastState, @maxDriver, index) ->
-        @id = @config.id
-        @name = @config.name
-        @_deviceId = @config.deviceId.toLowerCase()
-        @_contact = lastState?.contact?.value
-        @_battery = lastState?.battery?.value
-        @_index = index
-
-        @addAttribute(
-          'battery',
-          {
-            description: "state of the battery"
-            type: "boolean"
-            labels: ['low', 'ok']
-            acronym: "Bat."
-          }
-        )
-
-        @maxDriver.on('PushButtonStateRecieved',pushButtonStateReceivedHandler = (pushButtonState) =>
-          if(@_deviceId == pushButtonState.src)
-            # If the button state is open the isOpen field is true the contact is open = false
-            @_setContact(if pushButtonState.isOpen then false else true)
-            @_setBattery(pushButtonState.batteryLow)
-            env.logger.debug "PushButton with deviceId #{@_deviceId} updated"
-        )
-
-        @on('destroy', () =>
-          @maxDriver.removeListener('PushButtonStateRecieved', pushButtonStateReceivedHandler)
-          env.logger.debug "PushButton #{@_deviceId} PushButtonStateRecieved handler removed"
-        )
-
-        super()
-
-      getBattery:() -> Promise.resolve(@_battery)
-
-      _setBattery: (value) ->
-        if @_battery is value then return
-        @_battery = value
-        @emit 'battery', value
-
-      handleReceivedCmd: (command) ->
-
-      destroy: ->
-        env.logger.debug "PushButton #{@_deviceId} destroyed"
-        super()
-
-  # Class that represents a MAX! HeatingThermostat
-  class MaxculWallThermostat extends env.devices.HeatingThermostat
+  class MaxculThermostat extends env.devices.HeatingThermostat
 
     @_decalcDays: ["Sat","Sun","Mon","Tue","Wed","Thu","Fri"]
     @_modes: ["auto", "manu", "temporary", "boost"]
     @_boostDurations: [0,5,10,15,20,25,30,60]
-
-    @deviceType: "WallMountedThermostat"
-    template: "maxcul-wall-thermostat"
 
     _extendetAttributes:[
       {
@@ -378,11 +105,11 @@ module.exports = (env) ->
       @_minimumTemperature = @config.minimumTemperature
       @_maximumTemperature = @config.maximumTemperature
       @_measurementOffset = @config.measurementOffset
-<<<<<<< HEAD
+      @_windowOpenTime = @config.windowOpenTime
+      @_windowOpenTemperature = @config.windowOpenTemperature
+
       @_groupId = @config.groupId.toLowerCase()
-      @_pairId = @config.pairId.toLowerCase()
-=======
->>>>>>> 115f3a030020738f8744f2d1492d7f768c6763fe
+      @_pairIds = @config.pairIds
 
       @_timeInformationHour = ""
 
@@ -402,22 +129,10 @@ module.exports = (env) ->
           @_updateTimeInformation()
       )
 
-      @maxDriver.on('ThermostatStateRecieved', thermostatStateRecievedHandler = (thermostatState) =>
-        if(@_deviceId == thermostatState.src)
-          @_setBattery(thermostatState.batterylow)
-          @_setMode(@constructor._modes[thermostatState.mode])
-          @_setSetpoint(thermostatState.desiredTemperature)
-          if( thermostatState.measuredTemperature != 0)
-            @_setMeasuredTemperature(thermostatState.measuredTemperature)
-          @_setValve(thermostatState.valvePosition)
-      )
-
       @on('destroy', () =>
         @maxDriver.removeListener('deviceRequestTimeInformation', deviceRequestTimeInformationHandlder)
-        @maxDriver.removeListener('WallThermostatStateRecieved', thermostatStateRecievedHandler)
         @maxDriver.removeListener('checkTimeIntervalFired', checkTimeIntervalFiredHandler)
-
-        env.logger.debug "Thermostat #{@_deviceId} handlers removed"
+        env.logger.debug "Thermostat #{@_deviceId} base handlers removed"
       )
 
       super()
@@ -447,7 +162,7 @@ module.exports = (env) ->
         temperatureSetpoint = @_temperatureSetpoint
         env.logger.debug "Set desired mode to #{mode} for deviceId #{@_deviceId}"
 
-      @maxDriver.sendDesiredTemperature(@_deviceId, temperatureSetpoint, mode, "00", @constructor.deviceType).then( =>
+      @maxDriver.sendDesiredTemperature(@_deviceId, temperatureSetpoint, mode, @_groupId , @constructor.deviceType).then( =>
         @_lastSendTime = new Date().getTime()
         @_setMode(mode)
         @_setSetpoint(temperatureSetpoint)
@@ -459,7 +174,7 @@ module.exports = (env) ->
     changeTemperatureTo: (temperatureSetpoint) ->
       if @_temperatureSetpoint is temperatureSetpoint then return Promise.resolve true
       env.logger.debug "Set desired temperature #{temperatureSetpoint} for deviceId #{@_deviceId}"
-      @maxDriver.sendDesiredTemperature(@_deviceId, temperatureSetpoint, @_mode, "00", @constructor.deviceType).then( =>
+      @maxDriver.sendDesiredTemperature(@_deviceId, temperatureSetpoint, @_mode, @_groupId , @constructor.deviceType).then( =>
         @_lastSendTime = new Date().getTime()
         @_setSynced(true)
         @_setSetpoint(temperatureSetpoint)
@@ -470,16 +185,14 @@ module.exports = (env) ->
 
     transferConfigToDevice: () ->
       env.logger.info "transfer config to device #{@_deviceId}"
-<<<<<<< HEAD
-      if @_pairId != "000000"
-        @maxDriver.sendPair(@_deviceId,@_pairId,1,@constructor.deviceType)
-        env.logger.info "send pairId #{@_pairId} to device #{@_deviceId}"
-
+      for pid in @_pairIds
+        if pid.pairId != "000000"
+          @maxDriver.sendPair(@_deviceId,pid.pairId.toLowerCase(),pid.type,@constructor.deviceType)
+          env.logger.info "send pairId #{pid.pairId} to device #{@_deviceId}"
       if @_groupId != "00"
         @maxDriver.sendGroup(@_deviceId,@_groupId,@constructor.deviceType)
+        env.logger.info "send groupID #{@_groupId} to device #{@_deviceId}"
 
-=======
->>>>>>> 115f3a030020738f8744f2d1492d7f768c6763fe
       return @maxDriver.sendConfig(
           @_deviceId,
           @_comfortTemperature,
@@ -487,8 +200,8 @@ module.exports = (env) ->
           @_minimumTemperature,
           @_maximumTemperature,
           @_measurementOffset,
-          null,
-          null,
+          @_windowOpenTime,
+          @_windowOpenTemperature,
           @constructor.deviceType
         )
 
@@ -496,12 +209,233 @@ module.exports = (env) ->
     getComfortTemperature: () -> Promise.resolve(@_comfortTemperature)
     getMeasuredTemperature: () -> Promise.resolve(@_measuredTemperature)
 
-    getTemplateName: -> "maxcul-wall-thermostat"
+    # Class that represents a MAX! HeatingThermostat
+  class MaxculHeatingThermostat extends MaxculThermostat
+
+    @deviceType: "HeatingThermostat"
+    template: "maxcul-heating-thermostat"
+
+    constructor: (@config, lastState, @maxDriver, index) ->
+      super(@config, lastState, @maxDriver, index)
+      @_valve = lastState?.valve?.value
+
+      @maxDriver.on('ThermostatStateRecieved', thermostatStateRecievedHandler = (thermostatState) =>
+        if(@_deviceId == thermostatState.src)
+          @_setBattery(thermostatState.batterylow)
+          @_setMode(@constructor._modes[thermostatState.mode])
+          @_setSetpoint(thermostatState.desiredTemperature)
+          if( thermostatState.measuredTemperature != 0)
+            @_setMeasuredTemperature(thermostatState.measuredTemperature)
+          @_setValve(thermostatState.valvePosition)
+      )
+
+      @on('destroy', () =>
+        @maxDriver.removeListener('ThermostatStateRecieved', thermostatStateRecievedHandler)
+        env.logger.debug "Thermostat #{@_deviceId} extend handlers removed"
+      )
+
+    _setValve: (value) ->
+      if @_valve is value then return
+      @_valve = value
+      @emit 'valve', value
+
+    getTemplateName: -> "maxcul-heating-thermostat"
 
     destroy: ->
       env.logger.debug "Thermostat #{@_deviceId} destroyed"
       super()
 
+  # Class that represents a MAX! ShutterContact
+  class MaxculShutterContact extends env.devices.ContactSensor
+
+    @deviceType = "ShutterContact"
+
+    constructor: (@config, lastState, @maxDriver, index) ->
+      @id = @config.id
+      @name = @config.name
+      @_deviceId = @config.deviceId.toLowerCase()
+      @_contact = lastState?.contact?.value
+      @_battery = lastState?.battery?.value
+      @_index = index
+
+      @addAttribute(
+        'battery',
+        {
+          description: "state of the battery"
+          type: "boolean"
+          labels: ['low', 'ok']
+          acronym: "Bat."
+        }
+      )
+
+      @maxDriver.on('ShutterContactStateRecieved',shutterContactStateReceivedHandler = (shutterContactState) =>
+        if(@_deviceId == shutterContactState.src)
+          # If the window is open the isOpen field is true the contact is open = false
+          @_setContact(if shutterContactState.isOpen then false else true)
+          @_setBattery(shutterContactState.batteryLow)
+          env.logger.debug "ShutterContact with deviceId #{@_deviceId} updated"
+      )
+
+      @on('destroy', () =>
+        @maxDriver.removeListener('ShutterContactStateRecieved', shutterContactStateReceivedHandler)
+        env.logger.debug "ShutterContact #{@_deviceId} ShutterContactStateRecieved handler removed"
+      )
+
+      super()
+
+    getBattery:() -> Promise.resolve(@_battery)
+
+    _setBattery: (value) ->
+      if @_battery is value then return
+      @_battery = value
+      @emit 'battery', value
+
+    handleReceivedCmd: (command) ->
+
+    destroy: ->
+      env.logger.debug "ShutterContact #{@_deviceId} destroyed"
+      super()
+
+# Class that represents a MAX! ShutterContact
+  class MaxculFakeShutterContact extends env.devices.ContactSensor
+
+    @deviceType = "ShutterContact"
+
+    actions:
+      changeContactTo:
+        params:
+          contact:
+            type: "boolean"
+
+    constructor: (@config, lastState, @maxDriver, index) ->
+      @id = @config.id
+      @name = @config.name
+      @_deviceId = @config.deviceId.toLowerCase()
+      @_groupId = @config.groupId.toLowerCase()
+      @_pairId = @config.pairId.toLowerCase()
+      @_index = index
+
+      super()
+
+    changeContactTo: (contact) ->
+      @maxDriver.sendShutterMessage(@_pairId, @_deviceId, contact, @_groupId , @constructor.deviceType).then( =>
+        @_setContact(contact)
+        return Promise.resolve true
+      ).catch( (err) =>
+        return Promise.reject err
+      )
+
+    destroy: ->
+      env.logger.debug "ShutterContact #{@_deviceId} destroyed"
+      super()
+
+  # Class that represents a MAX! PushButton
+  class MaxculPushButton extends env.devices.ContactSensor
+
+    @deviceType = "PushButton"
+
+    constructor: (@config, lastState, @maxDriver, index) ->
+      @id = @config.id
+      @name = @config.name
+      @_deviceId = @config.deviceId.toLowerCase()
+      @_contact = lastState?.contact?.value
+      @_battery = lastState?.battery?.value
+      @_index = index
+
+      @addAttribute(
+        'battery',
+        {
+          description: "state of the battery"
+          type: "boolean"
+          labels: ['low', 'ok']
+          acronym: "Bat."
+        }
+      )
+
+      @maxDriver.on('PushButtonStateRecieved',pushButtonStateReceivedHandler = (pushButtonState) =>
+        if(@_deviceId == pushButtonState.src)
+          # If the button state is open the isOpen field is true the contact is open = false
+          @_setContact(if pushButtonState.isOpen then false else true)
+          @_setBattery(pushButtonState.batteryLow)
+          env.logger.debug "PushButton with deviceId #{@_deviceId} updated"
+      )
+
+      @on('destroy', () =>
+        @maxDriver.removeListener('PushButtonStateRecieved', pushButtonStateReceivedHandler)
+        env.logger.debug "PushButton #{@_deviceId} PushButtonStateRecieved handler removed"
+      )
+
+      super()
+
+    getBattery:() -> Promise.resolve(@_battery)
+
+    _setBattery: (value) ->
+      if @_battery is value then return
+      @_battery = value
+      @emit 'battery', value
+
+    handleReceivedCmd: (command) ->
+
+    destroy: ->
+      env.logger.debug "PushButton #{@_deviceId} destroyed"
+      super()
+
+  # Class that represents a MAX! WallThermostat
+  class MaxculWallThermostat extends MaxculThermostat
+
+    @deviceType: "WallMountedThermostat"
+    template: "maxcul-wall-thermostat"
+
+    constructor: (@config, lastState, @maxDriver, index) ->
+      super(@config, lastState, @maxDriver, index)
+
+      @maxDriver.on('WallThermostatStateRecieved', thermostatStateRecievedHandler = (thermostatState) =>
+        if(@_deviceId == thermostatState.src)
+          @_setBattery(thermostatState.batterylow)
+          @_setMode(@constructor._modes[thermostatState.mode])
+          @_setSetpoint(thermostatState.desiredTemperature)
+          if( thermostatState.measuredTemperature != 0)
+            @_setMeasuredTemperature(thermostatState.measuredTemperature)
+      )
+      @maxDriver.on('WallThermostatControlRecieved', thermostatStateRecievedHandler = (thermostatState) =>
+        if(@_deviceId == thermostatState.src)
+          @_setSetpoint(thermostatState.desired)
+          if( thermostatState.measured != 0)
+            @_setMeasuredTemperature(thermostatState.measured)
+      )
+
+      @on('destroy', () =>
+        @maxDriver.removeListener('WallThermostatStateRecieved', thermostatStateRecievedHandler)
+        @maxDriver.removeListener('WallThermostatControlRecieved', thermostatStateRecievedHandler)
+        env.logger.debug "WallThermostat #{@_deviceId} handlers removed"
+      )
+
+    getTemplateName: -> "maxcul-wall-thermostat"
+
+    destroy: ->
+      env.logger.debug "WallThermostat #{@_deviceId} destroyed"
+      super()
+
+  # Class that represents a MAX! Fake WallThermostat
+  class MaxculFakeWallThermostat extends MaxculThermostat
+
+    @deviceType: "WallMountedThermostat"
+    template: "maxcul-wall-thermostat"
+
+    constructor: (@config, lastState, @maxDriver, index) ->
+      super(@config, lastState, @maxDriver, index)
+
+    getTemplateName: -> "maxcul-wall-thermostat"
+
+    destroy: ->
+      env.logger.debug "WallFakeThermostat #{@_deviceId} destroyed"
+      super()
+
+    changeModeTo: (mode) ->
+      if @_mode is mode then return Promise.resolve true
+
+    changeTemperatureTo: (temperatureSetpoint) ->
+      if @_temperatureSetpoint is temperatureSetpoint then return Promise.resolve true
 
   maxculPlugin = new MaxculPlugin
   return maxculPlugin

--- a/maxcul.coffee
+++ b/maxcul.coffee
@@ -61,6 +61,15 @@ module.exports = (env) ->
         @framework.deviceManager.discoverMessage 'pimatic-maxcul', "pairmode for 30 sec enabled"
         @maxDriver.enablePairMode()
 
+      @maxDriver.on('NewDevice', (device,type) =>
+        config = {
+          name: "maxcul_#{device}",
+          id: "maxcul_#{device}",
+          address: device['9003']
+        }
+        @framework.deviceManager.discoveredDevice( 'pimatic-maxcul ', "New max device: #{config.name}", config )
+      )
+
     # Class that represents a MAX! HeatingThermostat
   class MaxculThermostat extends env.devices.HeatingThermostat
 

--- a/maxcul.coffee
+++ b/maxcul.coffee
@@ -416,7 +416,6 @@ module.exports = (env) ->
       @emit 'battery', @_battery
 
     _setContact: (value) ->
-      if @_contact is value then return
       @_contact = value
       @emit 'contact', value
       

--- a/maxcul.coffee
+++ b/maxcul.coffee
@@ -23,7 +23,8 @@ module.exports = (env) ->
       deviceTypeClasseNames = [
         MaxculShutterContact,
         MaxculHeatingThermostat,
-        MaxculPushButton
+        MaxculPushButton,
+        MaxculWallThermostat
       ]
 
       @maxDriver = new MaxDriver(baseAddress, @config.enablePairMode, @config.serialPortName, @config.baudrate)
@@ -76,7 +77,7 @@ module.exports = (env) ->
         },
         {
           name: 'battery'
-          settings: 
+          settings:
             label: "Battery State"
             description: "state of the battery"
             type: "string"
@@ -149,9 +150,9 @@ module.exports = (env) ->
         @emit 'measuredTemperature', measuredTemperature
 
       _setBattery: (value) ->
-        if ( value == 0 ) 
+        if ( value == 0 )
           @_battery = "ok"
-        else 
+        else
           @_battery = "low"
         @emit 'battery', @_battery
 
@@ -319,6 +320,163 @@ module.exports = (env) ->
       destroy: ->
         env.logger.debug "PushButton #{@_deviceId} destroyed"
         super()
+
+  # Class that represents a MAX! HeatingThermostat
+  class MaxculWallThermostat extends env.devices.HeatingThermostat
+
+    @_decalcDays: ["Sat","Sun","Mon","Tue","Wed","Thu","Fri"]
+    @_modes: ["auto", "manu", "temporary", "boost"]
+    @_boostDurations: [0,5,10,15,20,25,30,60]
+
+    @deviceType: "WallMountedThermostat"
+    template: "maxcul-wall-thermostat"
+
+    _extendetAttributes:[
+      {
+        name: 'measuredTemperature'
+        settings:
+          label: "Measured Temperature"
+          description: "The temp that the device has measured"
+          type: "number"
+          acronym: "T"
+          unit: "°C"
+      },
+      {
+        name: 'battery'
+        settings:
+          label: "Battery State"
+          description: "state of the battery"
+          type: "string"
+          labels: ['low', 'ok']
+          acronym: "Bat."
+      }
+    ]
+
+    constructor: (@config, lastState, @maxDriver, index) ->
+      @id = @config.id
+      @_index = index
+      @name = @config.name
+      @_deviceId = @config.deviceId.toLowerCase()
+      @_mode = lastState?.mode?.value or "auto"
+      @_battery = lastState?.battery?.value or "ok"
+      @_temperatureSetpoint = lastState?.temperatureSetpoint?.value or 17
+      @_measuredTemperature = lastState?.measuredTemperature?.value
+      @_lastSendTime = 0
+
+      @_comfortTemperature = @config.comfyTemp
+      @_ecoTemperature = @config.ecoTemp
+      @_minimumTemperature = @config.minimumTemperature
+      @_maximumTemperature = @config.maximumTemperature
+      @_measurementOffset = @config.measurementOffset
+
+      @_timeInformationHour = ""
+
+      @actions['transferConfigToDevice'] =
+        params:{}
+
+      for Attribute in @_extendetAttributes
+        do (Attribute) =>
+          @addAttribute(Attribute.name,Attribute.settings)
+
+      @maxDriver.on('checkTimeIntervalFired', checkTimeIntervalFiredHandler = () =>
+        @_updateTimeInformation()
+      )
+
+      @maxDriver.on('deviceRequestTimeInformation',deviceRequestTimeInformationHandlder = (device) =>
+        if device == @_deviceId
+          @_updateTimeInformation()
+      )
+
+      @maxDriver.on('ThermostatStateRecieved', thermostatStateRecievedHandler = (thermostatState) =>
+        if(@_deviceId == thermostatState.src)
+          @_setBattery(thermostatState.batterylow)
+          @_setMode(@constructor._modes[thermostatState.mode])
+          @_setSetpoint(thermostatState.desiredTemperature)
+          if( thermostatState.measuredTemperature != 0)
+            @_setMeasuredTemperature(thermostatState.measuredTemperature)
+          @_setValve(thermostatState.valvePosition)
+      )
+
+      @on('destroy', () =>
+        @maxDriver.removeListener('deviceRequestTimeInformation', deviceRequestTimeInformationHandlder)
+        @maxDriver.removeListener('WallThermostatStateRecieved', thermostatStateRecievedHandler)
+        @maxDriver.removeListener('checkTimeIntervalFired', checkTimeIntervalFiredHandler)
+
+        env.logger.debug "Thermostat #{@_deviceId} handlers removed"
+      )
+
+      super()
+
+    _setMeasuredTemperature: (measuredTemperature) ->
+      if @_measuredTemperature is measuredTemperature then return
+      @_measuredTemperature = measuredTemperature
+      @emit 'measuredTemperature', measuredTemperature
+
+    _setBattery: (value) ->
+      if ( value == 0 )
+        @_battery = "ok"
+      else
+        @_battery = "low"
+      @emit 'battery', @_battery
+
+    _updateTimeInformation: () ->
+      env.logger.debug "Updating time information for deviceId #{@_deviceId}"
+      @maxDriver.sendTimeInformation(@_deviceId,@constructor.deviceType)
+
+    changeModeTo: (mode) ->
+      if @_mode is mode then return Promise.resolve true
+
+      if mode is "auto"
+        temperatureSetpoint = null
+      else
+        temperatureSetpoint = @_temperatureSetpoint
+        env.logger.debug "Set desired mode to #{mode} for deviceId #{@_deviceId}"
+
+      @maxDriver.sendDesiredTemperature(@_deviceId, temperatureSetpoint, mode, "00", @constructor.deviceType).then( =>
+        @_lastSendTime = new Date().getTime()
+        @_setMode(mode)
+        @_setSetpoint(temperatureSetpoint)
+        return Promise.resolve true
+      ).catch ( (err) =>
+         return Promise.reject err
+      )
+
+    changeTemperatureTo: (temperatureSetpoint) ->
+      if @_temperatureSetpoint is temperatureSetpoint then return Promise.resolve true
+      env.logger.debug "Set desired temperature #{temperatureSetpoint} for deviceId #{@_deviceId}"
+      @maxDriver.sendDesiredTemperature(@_deviceId, temperatureSetpoint, @_mode, "00", @constructor.deviceType).then( =>
+        @_lastSendTime = new Date().getTime()
+        @_setSynced(true)
+        @_setSetpoint(temperatureSetpoint)
+        return Promise.resolve true
+      ).catch( (err) =>
+        return Promise.reject err
+      )
+
+    transferConfigToDevice: () ->
+      env.logger.info "transfer config to device #{@_deviceId}"
+      return @maxDriver.sendConfig(
+          @_deviceId,
+          @_comfortTemperature,
+          @_ecoTemperature,
+          @_minimumTemperature,
+          @_maximumTemperature,
+          @_measurementOffset,
+          null,
+          null,
+          @constructor.deviceType
+        )
+
+    getEcoTemperature: () -> Promise.resolve(@_ecoTemperature)
+    getComfortTemperature: () -> Promise.resolve(@_comfortTemperature)
+    getMeasuredTemperature: () -> Promise.resolve(@_measuredTemperature)
+
+    getTemplateName: -> "maxcul-wall-thermostat"
+
+    destroy: ->
+      env.logger.debug "Thermostat #{@_deviceId} destroyed"
+      super()
+
 
   maxculPlugin = new MaxculPlugin
   return maxculPlugin

--- a/maxcul.coffee
+++ b/maxcul.coffee
@@ -403,12 +403,17 @@ module.exports = (env) ->
     getTemplateName: -> "maxcul-contact"
 
     getBattery:() -> Promise.resolve(@_battery)
-
+  
     _setBattery: (value) ->
       if @_battery is value then return
       @_battery = value
       @emit 'battery', value
 
+    _setContact: (value) ->
+      if @_contact is value then return
+      @_contact = value
+      @emit 'contact', value
+      
     handleReceivedCmd: (command) ->
 
     transferConfigToDevice: () ->


### PR DESCRIPTION
HI Florian, 

i have added some new features. 

- **pairing mode** is activated **via"device discovery"** for 30 seconds
  - You do not need to change the plug-in configuration and restart pimatic
  - New paired devices are displayed in the discovery overview. 
- **new devices**
  - WallThermostat 
  - Fake Wall-Thermostat
     -  A reference temperature variable "refTemp" (expression) must be defined in the configuration.
 (expression)
     - refTemp changes are emited to the parId list (the internal heating thermostat sensor is deactivated if a wall-thermostat is paired)
     - The commands are passed to the pairIds list 
  - Fake Shutter-Device
     - The commands are passed to the pairId list
- **pair devices to each other**  
  - all devices can now be connected to each other
  - for this, all devices have now a config send button
  - with the new pairId config property and the config-send button, pairing ist transferred to the device. Pairing must be done reciprocally.
 - **all devices support now groupIDs** 
   - if a group is defined, commands are send to one device but now all devices in the same group are reacting to it
   - The group ID is also sent to the device using the config send button.
- I changed the valve position; i had the problem, that it was above the buttons
 maybe that's not a general problem?
- Overwriting the setContact function for issue #22
- The battery variable for all devices has been changed to string for issue #12

This need some testing. I don't have a shutter or a push button. 
Only wall thermostats and heating thermostats. 


If you want the pull request on another branch, let me know. 

keep in touch
Kosta